### PR TITLE
Add iota-description lang

### DIFF
--- a/common/src/main/resources/assets/ephemera/lang/en_us.json
+++ b/common/src/main/resources/assets/ephemera/lang/en_us.json
@@ -176,7 +176,9 @@
   "ephemera.page.forgewarning.1": "Mod author's note for Forge users: This spell does not work on Forge. I do not know why. I've set the cost on Forge to zero so at least it won't waste media. Sorry.$(br2)I'll try to get it working eventually.",
 
   "hexcasting.iota.ephemera:potion": "Status Effect",
+  "hexcasting.iota.ephemera:potion.desc": "a status iota",
   "hexcasting.iota.ephemera:hash": "Hash",
+  "hexcasting.iota.ephemera:hash.desc": "a hash",
   "ephemera.iota.hashlabel": "Hashed data: %s",
 
   "text.ephemera.clearHistoryResponse": "Cleared reveal history map.",


### PR DESCRIPTION
Going forward, addons should implement these lang keys for their iotas, for use in MishapInvalidIota.